### PR TITLE
fixed the winner section bug

### DIFF
--- a/views/teamgame.ejs
+++ b/views/teamgame.ejs
@@ -179,12 +179,12 @@
                                                     class="btn btn-outline-primary">Cancel Match</a>
                                                 <!-- Button trigger modal -->
                                                 <a type="button" class="btn btn-outline-primary" data-bs-toggle="modal"
-                                                    data-bs-target="#exampleModal1">
+                                                    data-bs-target="#exampleModal<%= index %>">
                                                     Declare Winner
                                                 </a>
 
                                                 <!-- Modal -->
-                                                <div class="modal fade" id="exampleModal1" tabindex="-1"
+                                                <div class="modal fade" id="exampleModal<%= index %>" tabindex="-1"
                                                     aria-labelledby="exampleModalLabe2" aria-hidden="true">
                                                     <div class="modal-dialog">
                                                         <div class="modal-content">


### PR DESCRIPTION
The bug arises during the winner declaration process, where the dropdown options for selecting the winner remain consistent for all matches. This issue has been identified and resolved to ensure that each match presents the correct and distinct set of options when declaring the winner. The fix addresses the uniformity problem, ensuring accurate and unique winner selections for each match in the application.